### PR TITLE
updated to compile against HISE master 8ef678e

### DIFF
--- a/AdditionalSourceCode/Raw.cpp
+++ b/AdditionalSourceCode/Raw.cpp
@@ -3,7 +3,7 @@
 #if USE_RAW_FRONTEND
 
 VCSLData::VCSLData(MainController* mc) :
-    RawDataBase(mc)
+    DataHolderBase(mc)
 {
     auto storagePtr = &storedData;
   
@@ -77,7 +77,7 @@ VCSLData::VCSLData(MainController* mc) :
 
 
 /** This method needs to be implemented and your initial preset structure must be defined here. */
-FrontendProcessor::RawDataBase* FrontendProcessor::createPresetRaw()
+raw::DataHolderBase* FrontendProcessor::createPresetRaw()
 {
 	return new VCSLData(this);
 }

--- a/AdditionalSourceCode/Raw.h
+++ b/AdditionalSourceCode/Raw.h
@@ -11,7 +11,7 @@ class ColourMidiProcessor : public hise::HardcodedScriptProcessor
 public:
 
 	/** Set the name and default ID of the processor. */
-	SET_PROCESSOR_NAME("Colour", "Colour");
+	SET_PROCESSOR_NAME("Colour", "Colour", "Colour");
 
 	enum Parameters
 	{
@@ -38,7 +38,7 @@ public:
 	JUCE_DECLARE_WEAK_REFERENCEABLE(ColourMidiProcessor);
 };
 
-class VCSLData : public FrontendProcessor::RawDataBase
+class VCSLData : public hise::raw::DataHolderBase
 {
 public:
 

--- a/AdditionalSourceCode/RawEditor.cpp
+++ b/AdditionalSourceCode/RawEditor.cpp
@@ -114,7 +114,7 @@ VCSOInterface::VCSOInterface(VCSLData* data) :
 	presetBrowserBg.addAndMakeVisible(presetBrowser);
 
 	presetBrowser.setName("PresetBrowser");
-	presetBrowser.pblaf.modalBackgroundColour = Colours::black.withAlpha(0.3f);
+	presetBrowser.pblaf->modalBackgroundColour = Colours::black.withAlpha(0.3f);
 
 	PresetBrowser::Options newOptions;
 


### PR DESCRIPTION
HISE codebase also needs this method:

**hi_modules/raw/raw_misc.h**
```
const juce::StringArray getSampleMapList();
```

**hi_modules/raw/raw_misc.cpp**
```
const juce::StringArray Pool::getSampleMapList()
{
  WARN_IF_AUDIO_THREAD(true, ScriptGuard::IllegalApiCall); 
  Array<var> sampleMapNames;
 
  auto pool = getMainController()->getCurrentSampleMapPool();
  auto references = pool->getListOfAllReferences(true);
 
  PoolReference::Comparator comparator; 
  references.sort(comparator);
 
  sampleMapNames.ensureStorageAllocated(references.size()); 
  for (auto r : references)
    sampleMapNames.add(r.getReferenceString());
 
  return sampleMapNames;
}
```
